### PR TITLE
Fix comment characters in hyprland v0.36

### DIFF
--- a/rose-pine-dawn.conf
+++ b/rose-pine-dawn.conf
@@ -1,7 +1,7 @@
-## name: Rosé Pine Dawn
-## author: jishnurajendran
-## upstream: https://github.com/jishnurajendran/hyprland-rosepine/blob/main/rose-pine-dawn.conf
-## All natural pine, faux fur and a bit of soho vibes for the classy minimalist
+# name: Rosé Pine Dawn
+# author: jishnurajendran
+# upstream: https://github.com/jishnurajendran/hyprland-rosepine/blob/main/rose-pine-dawn.conf
+# All natural pine, faux fur and a bit of soho vibes for the classy minimalist
 $base	        = 0xfffaf4ed
 $surface        = 0xfffffaf3
 $overlay        = 0xfff2e9e1

--- a/rose-pine-moon.conf
+++ b/rose-pine-moon.conf
@@ -1,7 +1,7 @@
-## name: Rosé Pine Moon
-## author: jishnurajendran
-## upstream: https://github.com/jishnurajendran/hyprland-rosepine/blob/main/rose-pine-moon.conf
-## All natural pine, faux fur and a bit of soho vibes for the classy minimalist
+# name: Rosé Pine Moon
+# author: jishnurajendran
+# upstream: https://github.com/jishnurajendran/hyprland-rosepine/blob/main/rose-pine-moon.conf
+# All natural pine, faux fur and a bit of soho vibes for the classy minimalist
 $base	        = 0xff232136
 $surface        = 0xff2a273f
 $overlay        = 0xff393552

--- a/rose-pine.conf
+++ b/rose-pine.conf
@@ -1,7 +1,7 @@
-## name: Rosé Pine
-## author: jishnurajendran
-## upstream: https://github.com/jishnurajendran/hyprland-rosepine/blob/main/rose-pine.conf
-## All natural pine, faux fur and a bit of soho vibes for the classy minimalist
+# name: Rosé Pine
+# author: jishnurajendran
+# upstream: https://github.com/jishnurajendran/hyprland-rosepine/blob/main/rose-pine.conf
+# All natural pine, faux fur and a bit of soho vibes for the classy minimalist
 $base           = 0xff191724
 $surface        = 0xff1f1d2e
 $overlay        = 0xff26233a


### PR DESCRIPTION
Since [hyprland's config migration to hyprlang in v0.36](https://github.com/hyprwm/Hyprland/releases/tag/v0.36.0), as they wrote:
> `##` is now properly treated as an escaped `#`.

As a result, the theme's comments break the hyprland config.
I edited them to be compatible with the new config language.